### PR TITLE
Using PUBLIC_URL on the dev server if existent

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -61,10 +61,7 @@ module.exports = function(webpackEnv) {
 
   // Webpack uses `publicPath` to determine where the app is being served from.
   // It requires a trailing slash, or the file assets will get an incorrect path.
-  // In development, we always serve from the root. This makes config easier.
-  const publicPath = isEnvProduction
-    ? paths.servedPath
-    : isEnvDevelopment && '/';
+  const publicPath = paths.servedPath;
   // Some apps do not use client-side routing with pushState.
   // For these, "homepage" can be set to "." to enable relative asset paths.
   const shouldUseRelativeAssetPaths = publicPath === './';

--- a/packages/react-scripts/config/webpackDevServer.config.js
+++ b/packages/react-scripts/config/webpackDevServer.config.js
@@ -67,8 +67,8 @@ module.exports = function(proxy, allowedHost) {
     // to CSS are currently hot reloaded. JS changes will refresh the browser.
     hot: true,
     // It is important to tell WebpackDevServer to use the same "root" path
-    // as we specified in the config. In development, we always serve from /.
-    publicPath: '/',
+    // as we specified in the config. In development, we serve using the PUBLIC_URL or /.
+    publicPath: process.env.PUBLIC_URL || '/',
     // WebpackDevServer is noisy by default so we emit custom message instead
     // by listening to the compiler events with `compiler.hooks[...].tap` calls above.
     quiet: true,


### PR DESCRIPTION
We need the PUBLIC_URL on development also.
